### PR TITLE
fix for citymap - old ages count was off by one

### DIFF
--- a/js/web/citymap/js/citymap.js
+++ b/js/web/citymap/js/citymap.js
@@ -413,10 +413,10 @@ let CityMap = {
 		
 		let legends = [];
 		
-		legends.push(`<span class="older-1 diagonal"></span> ${$('.older-1').length-1} ${i18n('Boxes.CityMap.OlderThan1Era')}<br>`);
-		legends.push(`<span class="older-2 diagonal"></span> ${$('.older-2').length-1} ${i18n('Boxes.CityMap.OlderThan2Era')}<br>`);
-		legends.push(`<span class="older-3 diagonal"></span> ${$('.older-3').length-1} ${i18n('Boxes.CityMap.OlderThan3Era')}<br>`);
-		legends.push(`<span class="to-old diagonal"></span> ${$('.to-old').length-1} ${i18n('Boxes.CityMap.OlderThan4Era')}<br>`);
+		legends.push(`<span class="older-1 diagonal"></span> ${$('#map-container .older-1').length} ${i18n('Boxes.CityMap.OlderThan1Era')}<br>`);
+		legends.push(`<span class="older-2 diagonal"></span> ${$('#map-container .older-2').length} ${i18n('Boxes.CityMap.OlderThan2Era')}<br>`);
+		legends.push(`<span class="older-3 diagonal"></span> ${$('#map-container .older-3').length} ${i18n('Boxes.CityMap.OlderThan3Era')}<br>`);
+		legends.push(`<span class="to-old diagonal"></span> ${$('#map-container .to-old').length} ${i18n('Boxes.CityMap.OlderThan4Era')}<br>`);
 
 		$('.to-old-legends').html(legends.join(''));
 	},


### PR DESCRIPTION
in the citymap, the count of buildings of older ages was off by one (for all 4 categories):
![image](https://user-images.githubusercontent.com/8438121/154850939-8d580f4e-15d7-465e-975a-ae0c034b42ae.png)

i'm not surre if originally the spans of the labels were also counted (as they have the same classes as the rectangles in the map) or if this is still the case, so just to be sure i also changed the selector, so only elements within the #map-container will be counted