### PR TITLE
Fix for Guild Battlegrounds snapshot log

### DIFF
--- a/js/web/guildfights/js/guildfights.js
+++ b/js/web/guildfights/js/guildfights.js
@@ -846,7 +846,7 @@ let GildFights = {
 			h.push('</thead><tbody class="gbg-playerlog-group">');
 
 			dailyFights.forEach(day => {
-				let id = moment.unix(day.time).format(i18n('YYYYMMDD'));
+				let id = moment.unix(day.time).format('YYYYMMDD');
 				let sum = (day.battles + day.negotiations * 2);
 				h.push('<tr id="gbgdetail_' + id + '" data-gbground="' + gbground + '" data-player="' + player_id + '" data-id="' + id + '" class="hasdetail">');
 				h.push(`<td class="is-number" data-number="${day.time}">${moment.unix(day.time).format(i18n('Date'))}</td>`);


### PR DESCRIPTION
The dates under each user's snapshot log on GBG Overview cannot be expanded.

Steps to reproduce:
1. Go to Guild Battleground
2. Open GBG Overview
3. Click on a player entry to open the snapshot log
4. Attempt to expand any date entry.
5. The following error appears:

    Uncaught (in promise) Error: Syntax error, unrecognized expression: #gbgdetail_???
        at Function.se.error (merged-3rd-party-818a5bbc.js:3:13639)
        at se.tokenize (merged-3rd-party-818a5bbc.js:3:21650)
        at se.select (merged-3rd-party-818a5bbc.js:3:22477)
        at Function.se [as find] (merged-3rd-party-818a5bbc.js:3:7116)
        at S.fn.init.find (merged-3rd-party-818a5bbc.js:3:25047)
        at new S.fn.init (merged-3rd-party-818a5bbc.js:3:25536)
        at S (merged-3rd-party-818a5bbc.js:3:1051)
        at Object.BuildDetailViewLog (guildfights.js?v=2.7.0.0:983:29