### PR TITLE
Conflict identifying a html element between Infobox and GB Calculator.

### DIFF
--- a/js/web/part-calc/js/part-calc.js
+++ b/js/web/part-calc/js/part-calc.js
@@ -1115,7 +1115,7 @@ let Parts = {
 
 		// Container zusammen setzen
 		let div = $('<div />').addClass('OwnPartBoxBackground'),
-			a = $('<div />').addClass('outerArrow').append( $('<span />').addClass('arrow game-cursor') ).append( $('<div />').addClass('OwnPartBoxBackgroundBody window-box').append(h.join('')) );
+			a = $('<div />').addClass('outerArrow').append( $('<span />').addClass('arrow game-cursor').attr('id', 'OwnPartBoxArrow') ).append( $('<div />').addClass('OwnPartBoxBackgroundBody window-box').append(h.join('')) );
 
 		$OwnPartBox
 			.append( div.append(a) )
@@ -1124,7 +1124,7 @@ let Parts = {
 
 		// der "Toogle"-Pfeil wurde geklickt,
 		// lasst die Spiele beginnen
-		$('.arrow').bind('click', function(){
+		$('#OwnPartBoxArrow').bind('click', function(){
 			if( $OwnPartBox.hasClass('show') ){
 				Parts.BackGroundBoxAnimation(false);
 			} else {


### PR DESCRIPTION
_Infobox's_ filter's arrow has class `arrow`, same as _GB Calculator's Copy values'_ settings' arrow.
_GB Calculator's_ arrow binds its click action to all `arrow`s, including _Infobox's_.

Steps to reproduce:
1. Open _Infobox_
1. Open _GB Calculator_
1. Click on _Infobox's_ filter's arrow, _GB Calculator's_ settings window shows up
1. Click on _Infobox's_ filter's arrow again, _GB Calculator's_ settings window hides
1. Close _GB Calculator_
1. Click on _Infobox's_ filter's arrow, `TypeError: Cannot read property 'style' of undefined` shows up in the console.
