### PR TITLE
Update GB Calculator

### DIFF
--- a/js/web/part-calc/js/part-calc.js
+++ b/js/web/part-calc/js/part-calc.js
@@ -684,7 +684,7 @@ let Parts = {
 		}
 		
         // Level is locked
-		if (PlayerID === ExtPlayerID && MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level) {
+		if (Parts.CityMapEntity['player_id'] !== ExtPlayerID && MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level) {
 			h.push('<div class="lg-not-possible" data-text="'+i18n('Boxes.Calculator.LGNotOpen')+'"></div>');
 		}
 		// Info-Block
@@ -906,7 +906,15 @@ let Parts = {
 			}
 			h.push('<div class="bottom-buttons text-center">');
 			h.push('<div class="btn-group">');
-			if (Parts.SafePlaces.length > 0 || Parts.CopyModeAll) { //Copy bzw. Note Button nur einblenden wenn zumindest ein Platz safe ist
+			
+			// Check if GB belongs to the user and is locked
+			if (
+				Parts.CityMapEntity.player_id === ExtPlayerID &&
+				MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level
+			) {
+				h.push(i18n('Boxes.Calculator.LGNotOpen'));
+			}
+			else if (Parts.SafePlaces.length > 0 || Parts.CopyModeAll) { //Copy bzw. Note Button nur einblenden wenn zumindest ein Platz safe ist
 				h.push('<span class="btn-default button-own">' + i18n('Boxes.OwnpartCalculator.CopyValues') + '</span>');
 				if (Parts.CityMapEntity['player_id'] === ExtPlayerID) h.push('<span class="btn-default button-save-own">' + i18n('Boxes.OwnpartCalculator.Note') + '</span>');
 			}
@@ -1691,3 +1699,4 @@ let Parts = {
 		});
 	}
 };
+


### PR DESCRIPTION
Overlay of locked building only for external buildings, while no button rendered for Own GB. same text used
<img width="417" height="536" alt="image" src="https://github.com/user-attachments/assets/5eda4a76-5530-403c-9ac3-fee172aaf842" />
<img width="419" height="539" alt="image" src="https://github.com/user-attachments/assets/7d71e2ec-8cc9-4ab0-8fb0-b3bbc800c4f7" />
