### PR TITLE
Gb calculator

### DIFF
--- a/js/web/part-calc/js/part-calc.js
+++ b/js/web/part-calc/js/part-calc.js
@@ -684,7 +684,7 @@ let Parts = {
 		}
 		
         // Level is locked
-		if (Parts.CityMapEntity['player_id'] !== ExtPlayerID && MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level) {
+		if (Parts.CityMapEntity['player_id'] !== ExtPlayerID && Parts.CityMapEntity['level'] === Parts.CityMapEntity['max_level']) {
 			h.push('<div class="lg-not-possible" data-text="'+i18n('Boxes.Calculator.LGNotOpen')+'"></div>');
 		}
 		// Info-Block
@@ -1699,4 +1699,5 @@ let Parts = {
 		});
 	}
 };
+
 

--- a/js/web/part-calc/js/part-calc.js
+++ b/js/web/part-calc/js/part-calc.js
@@ -684,7 +684,7 @@ let Parts = {
 		}
 		
         // Level is locked
-		if (PlayerID === ExtPlayerID && MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level) {
+		if (Parts.CityMapEntity['player_id'] !== ExtPlayerID && MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level) {
 			h.push('<div class="lg-not-possible" data-text="'+i18n('Boxes.Calculator.LGNotOpen')+'"></div>');
 		}
 		// Info-Block
@@ -906,7 +906,15 @@ let Parts = {
 			}
 			h.push('<div class="bottom-buttons text-center">');
 			h.push('<div class="btn-group">');
-			if (Parts.SafePlaces.length > 0 || Parts.CopyModeAll) { //Copy bzw. Note Button nur einblenden wenn zumindest ein Platz safe ist
+			
+			// Check if GB belongs to the user and is locked
+			if (
+				Parts.CityMapEntity.player_id === ExtPlayerID &&
+				MainParser.CityMapData[Parts.CityMapEntity.id]?.level === MainParser.CityMapData[Parts.CityMapEntity.id]?.max_level
+			) {
+				h.push(i18n('Boxes.Calculator.LGNotOpen'));
+			}
+			else if (Parts.SafePlaces.length > 0 || Parts.CopyModeAll) { //Copy bzw. Note Button nur einblenden wenn zumindest ein Platz safe ist
 				h.push('<span class="btn-default button-own">' + i18n('Boxes.OwnpartCalculator.CopyValues') + '</span>');
 				if (Parts.CityMapEntity['player_id'] === ExtPlayerID) h.push('<span class="btn-default button-save-own">' + i18n('Boxes.OwnpartCalculator.Note') + '</span>');
 			}
@@ -1691,3 +1699,4 @@ let Parts = {
 		});
 	}
 };
+


### PR DESCRIPTION
Overlay implemented on locked external GB's, and replaced with note instead of buttons for Own GB. same text used as for overlay
<img width="417" height="536" alt="image" src="https://github.com/user-attachments/assets/24e47179-2997-4386-8fee-defe3bc225e9" />
<img width="419" height="539" alt="image" src="https://github.com/user-attachments/assets/9463a783-91c3-4e57-b229-ed4fe0659378" />
